### PR TITLE
Allow specifying Docker listen ports through environment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,14 +2,18 @@
 
 # This shell script sets the api url based on an environment variable and starts nginx in foreground.
 
-if [ -z "$VIKUNJA_API_URL" ]; then
-  VIKUNJA_API_URL="/api/v1"
-fi
+VIKUNJA_API_URL="${VIKUNJA_API_URL:-"/api/v1"}"
+
+VIKUNJA_HTTP_PORT="${VIKUNJA_HTTP_PORT:-80}"
+VIKUNJA_HTTPS_PORT="${VIKUNJA_HTTP_PORT:-443}"
 
 # Escape the variable to prevent sed from complaining
 VIKUNJA_API_URL=$(echo $VIKUNJA_API_URL |sed 's/\//\\\//g')
 
 sed -i "s/http\:\/\/localhost\:3456\/api\/v1/$VIKUNJA_API_URL/g" /usr/share/nginx/html/index.html
+
+sed -i "s/listen 80/listen $VIKUNJA_HTTP_PORT/g" nginx.conf
+sed -i "s/listen 443/listen $VIKUNJA_HTTPS_PORT/g" nginx.conf
 
 # Set the uid and gid of the nginx run user
 usermod --non-unique --uid ${PUID} nginx


### PR DESCRIPTION
Hi!

While Docker containers have their own IP address namespace and port collisions are impossible to achieve, other container solutions share one.
Podman, for example, runs all containers in a pod under one namespace, which results in every port only being allowed to be assigned once. Having a default port in the image that cannot be changed can cause collisions and incompabilities.

This change allows setting a custom port for nginx through the environment while keeping the default port as fallback to keep backwards compatibility.

I've also taken the freedom and changed the `$VIKUNJA_API_URL` check to use the shorthand.

Will be happy to add this to the docs as well if you decide to merge.

Cheers!