### PR TITLE
PWA share target implementation

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,10 +3,54 @@
 
 import {getFullBaseUrl} from './helpers/getFullBaseUrl'
 
+import {useTaskStore} from '@/stores/tasks'
+import {useAuthStore} from '@/stores/auth'
+
 declare let self: ServiceWorkerGlobalScope
 
 const fullBaseUrl = getFullBaseUrl()
+const authStore = useAuthStore()
+const taskStore = useTaskStore()
 const workboxVersion = 'v7.0.0'
+
+
+const shareTargetHandler = async ({event}) => {	
+	console.log('share-target()  ', event)
+
+	// Form extraction works fine...
+	const formData = await event.request.formData()
+	console.log('FormData:()  ', formData)
+	const title = formData.get('name')
+	const description = formData.get('description')
+
+	console.log('shareTargetHandler(), title: ', title)
+	console.log('shareTargetHandler(), description: ', description)
+
+	const defaultProjectId = authStore?.settings?.defaultProjectId
+	console.log('shareTargetHandler(), defaultProjectId: ', defaultProjectId)
+
+	if (defaultProjectId) {
+		const task = await taskStore.createNewTask({
+			title,
+			projectId: defaultProjectId,
+		})
+
+		if (description) {
+			task.description = description
+		}
+
+		console.log('Created task with ID: ', task.id)
+	
+		// After Task creation succeeds, redirect to show the task.
+		const redirectionUrl = `${fullBaseUrl}tasks/${task.id}`
+		return Response.redirect(redirectionUrl, 303)
+	}
+	else {
+		// ToDo: improve handling of undefined default projectID
+		const redirectionUrl = `${fullBaseUrl}unspecified_default_project_id`
+		return Response.redirect(redirectionUrl, 303)
+	}
+}
 
 importScripts(`${fullBaseUrl}workbox-${workboxVersion}/workbox-sw.js`)
 workbox.setConfig({
@@ -28,6 +72,12 @@ workbox.routing.registerRoute(
 workbox.routing.registerRoute(
 	new RegExp('api\\/v1\\/.*$'),
 	new workbox.strategies.NetworkOnly(),
+)
+
+workbox.routing.registerRoute(
+	'/_share-target',
+	shareTargetHandler,
+	'POST',
 )
 
 // This code listens for the user's confirmation to update the app.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -202,6 +202,15 @@ export default defineConfig(({mode}) => {
 							url: '/teams',
 						},
 					],
+					share_target: {
+						action: '/_share-target',
+						enctype: 'multipart/form-data',
+						method: 'POST',
+						params: {
+							title: 'name',
+							text: 'description',
+						},
+					},
 				},
 			}),
 			viteSentry(getSentryConfig(env)),


### PR DESCRIPTION
This is an intitial step towards the implementation of a `share_target` for PWA, as requested in #51.

The intended workings of it are to register a `share_target` for the PWA to accept text, which would then be used to create a new task with the provided text as Title & Description of this task, and then to open the task view for the user to further edit.

Registration of the handler, receiving the provided data, and forwarding to a task view upon success are working as expected. However use of the `TaskStore` and `AuthStore` cause `pnpm run build` to error out with seemingly useless parsing errors. 

I'm no frontend dev and quite unfamiliar with anything JS. Hopefully someone with more experience is able to further aid the implementation of this feature.